### PR TITLE
Implemented uploading PDF file

### DIFF
--- a/src/main/java/finki/ikt/iktproekt/controller/DocumentController.java
+++ b/src/main/java/finki/ikt/iktproekt/controller/DocumentController.java
@@ -1,0 +1,56 @@
+package finki.ikt.iktproekt.controller;
+
+import finki.ikt.iktproekt.Service.DocumentService;
+import finki.ikt.iktproekt.Service.UserService;
+import finki.ikt.iktproekt.model.Document;
+import finki.ikt.iktproekt.model.User;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@RestController
+@RequestMapping("/api/documents")
+public class DocumentController {
+    private final DocumentService documentService;
+    private final UserService userService;
+
+    public DocumentController(DocumentService documentService, UserService userService) {
+        this.documentService = documentService;
+        this.userService = userService;
+    }
+
+    @PostMapping("/upload")
+    public ResponseEntity<String> uploadFile(@RequestParam("file") MultipartFile file, @RequestParam("userId") Long userId) {
+        // Check if the file is PDF
+        if (file.isEmpty() || !file.getContentType().equals("application/pdf")) {
+            return ResponseEntity.badRequest().body("Wrong file type. File must be PDF.");
+        }
+
+        // File size validation
+        if (file.getSize() > 10 * 1024 * 1024) {
+            return ResponseEntity.badRequest().body("File size must be less than 10MB");
+        }
+
+        // Saving the file locally
+        String filePath = "uploads/" + file.getOriginalFilename();
+        try {
+            Path path = Paths.get(filePath);
+            Files.createDirectories(path.getParent());
+            file.transferTo(path);
+        } catch (IOException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("File saving failed");
+        }
+
+        User user = userService.findById(userId).orElseThrow(() -> new RuntimeException("User not found"));
+        Document document = new Document(null, user, filePath, false, null);
+
+        documentService.create(document);
+
+        return ResponseEntity.ok("File uploaded successfully");
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,5 +12,6 @@ spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
-
-
+# Spring Servlet API for handling file uploads
+spring.servlet.multipart.max-file-size=10MB
+#spring.servlet.multipart.max-request-size=10MB (default value)


### PR DESCRIPTION
To upload a PDF file, send a POST request to http://localhost:8080/api/upload with the file and userId as key-value pairs. The file key should contain the PDF file, and the userId key should contain the ID of the user associated with the file.